### PR TITLE
feat: add initial rules catalog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# We suggest using a pre-commit hook to automate lints/formatting.
+# [install pre-commit](https://pre-commit.com/#installation), then run
+# pre-commit install
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  - repo: https://github.com/syntaqx/git-hooks
+    rev: v0.0.17
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.4.0"
+    hooks:
+      - id: prettier

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,0 +1,12 @@
+# Working with the catalog
+
+We expect you have `jq` installed to work with the dataset.
+See https://stedolan.github.io/jq/download/
+
+## Update stats
+
+Run `./catalog/scrape_data.sh`
+
+## Add a new ruleset
+
+TODO: a `jq` one-liner that makes this hard to get wrong

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -5,7 +5,7 @@ See https://stedolan.github.io/jq/download/
 
 ## Update stats
 
-Run `./catalog/scrape_data.sh`
+Run `./scrape_data.sh`
 
 ## Add a new ruleset
 

--- a/catalog/rulesets.js
+++ b/catalog/rulesets.js
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview read our config.json files, setting default values
+ */
+
+function titleCase(s) {
+  return s.charAt(0).toUpperCase() + s.substr(1);
+}
+
+function readConfig() {
+  const config = require("./rulesets.json");
+  config.rulesets.forEach((cfg) => {
+    cfg.shortname ||= titleCase(
+      cfg.ghrepo.split("/")[1].substring("rules_".length)
+    );
+    cfg.repository ||= cfg.ghrepo.split("/")[1].replace("-", "_");
+  });
+  return config;
+}
+
+module.exports = readConfig;
+
+if (require.main === module) {
+  console.log(JSON.stringify(readConfig()));
+}

--- a/catalog/rulesets.json
+++ b/catalog/rulesets.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "./rulesets.schema.json",
+  "rulesets": [
+    {
+      "ghrepo": "bazelbuild/bazel-skylib",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_android"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_appengine"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_apple",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_cc"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_closure"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_d"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_docker",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_dotnet",
+      "shortname": ".NET"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_foreign_cc"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_fuzzing"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_go",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_groovy"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_gwt"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_java"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_jsonnet"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_jvm_external",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_k8s",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_kotlin"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_license"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_nodejs",
+      "bazel-recommended": true,
+      "repository": "build_bazel_rules_nodejs"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_perl"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_pkg",
+      "shortname": "Packaging",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_postcss"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_proto",
+      "shortname": "Protocol Buffers",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_python",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_rust"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_sass"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_scala",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "bazelbuild/rules_swift"
+    },
+    {
+      "ghrepo": "bazelbuild/rules_webtesting",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "nelhage/rules_boost",
+      "bazel-recommended": true
+    },
+    {
+      "ghrepo": "tweag/rules_haskell",
+      "bazel-recommended": true
+    }
+  ]
+}

--- a/catalog/rulesets.schema.json
+++ b/catalog/rulesets.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/bazel-contrib/catalog-entry.schema.json",
+  "title": "Ruleset Config",
+  "type": "object",
+  "properties": {
+    "$schema": { "type": "string" },
+    "rulesets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ghrepo": {
+            "description": "GitHub repository",
+            "type": "string"
+          },
+          "bazel-recommended": {
+            "description": "whether this ruleset is listed on https://docs.bazel.build/rules.html#recommended-rules",
+            "type": "boolean"
+          },
+          "shortname": {
+            "description": "human-readable shorter name for navigation, like rules_pkg is Packaging. Defaults to just title case of the repo name.",
+            "type": "string"
+          },
+          "repository": {
+            "type": "string",
+            "description": "what name this ruleset documents that users should load() its symbols from"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["ghrepo"]
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["rulesets"]
+}

--- a/catalog/scrape_data.sh
+++ b/catalog/scrape_data.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Uses GitHub API to gather updates on the rulesets
+# - show how active they are, recent releases, etc
+# - TODO: what other data can we gather...
+
+set -o errexit -o pipefail -o nounset
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+GH_TOKEN=${GH_TOKEN:-error you must set a github token}
+
+function debug() {
+    # echo $@
+    true
+}
+
+function ghapi() {
+    curl 2>/dev/null \
+        -u "$USER:$GH_TOKEN" \
+        -H "Accept: application/vnd.github.v3+json" \
+        "https://api.github.com/$1"
+}
+
+# Make the function visible to subshells
+export -f ghapi
+
+node "$SCRIPT_DIR/rulesets.js" | \
+  jq -r '.rulesets[]|[.ghrepo] | @tsv' |
+  tr '\t' ',' |
+  while IFS=$',' read -r ghrepo; do
+    out="$SCRIPT_DIR/$ghrepo"
+    mkdir -p "$out"
+    ghapi "repos/$ghrepo" > "$out"/repo.json
+    ghapi "repos/$ghrepo/stats/participation" | jq .all > "$out"/participation.json
+    ghapi "repos/$ghrepo/community/profile" > "$out"/community_profile.json
+    # rules_jvm_external has some tags starting with "2018"
+    # so we filter those out here by looking only for tags with a dot
+    latest_tag=$(ghapi repos/"$ghrepo"/tags |\
+        jq -r '[.[] | select(.name | contains("."))] | .[0].name')
+    
+    ghapi "repos/$ghrepo/commits/$latest_tag" | jq -r .commit > "$out"/latest_tag.json
+done
+
+date > "$SCRIPT_DIR/last_updated.txt"

--- a/catalog/scrape_data.sh
+++ b/catalog/scrape_data.sh
@@ -6,7 +6,7 @@
 set -o errexit -o pipefail -o nounset
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-GH_TOKEN=${GH_TOKEN:-error you must set a github token}
+: ${GH_TOKEN:-error you must set a github token}
 
 function ghapi() {
     curl 2>/dev/null \

--- a/catalog/scrape_data.sh
+++ b/catalog/scrape_data.sh
@@ -10,6 +10,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 function ghapi() {
     curl 2>/dev/null \
+        --retry 5 \
         -u "$USER:$GH_TOKEN" \
         -H "Accept: application/vnd.github.v3+json" \
         "https://api.github.com/$1"

--- a/catalog/scrape_data.sh
+++ b/catalog/scrape_data.sh
@@ -8,11 +8,6 @@ set -o errexit -o pipefail -o nounset
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 GH_TOKEN=${GH_TOKEN:-error you must set a github token}
 
-function debug() {
-    # echo $@
-    true
-}
-
 function ghapi() {
     curl 2>/dev/null \
         -u "$USER:$GH_TOKEN" \


### PR DESCRIPTION
This includes a config file listing all known repos, which we will add to over time,
a schema and JS file to provide default values, a Bash script that scrapes data for each ruleset,
and finally a checked in copy of the raw data for each ruleset.

In the future we'll want some tooling to present the data or export it into other tooling like a spreadsheet
similar to https://docs.aspect.dev/stats